### PR TITLE
Fix cmd line call to work in non-unix shells like cmd on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "serve.prod": "gulp serve --prod",
     "build.dev": "gulp build",
     "build.prod": "gulp build --prod",
-    "postinstall": "./node_modules/protractor/bin/webdriver-manager update",
+    "postinstall": "node node_modules/protractor/bin/webdriver-manager update",
     "test": "gulp test:unit",
     "test.e2e": "gulp test:e2e"
   }


### PR DESCRIPTION
Hi Guys,

On windows 10 this fails npm install currently:

`C:\Users\Craig\Code\clarity-seed>npm install
> clarity-seed@0.6.0 postinstall C:\Users\Craig\Code\clarity-seed
> ./node_modules/protractor/bin/webdriver-manager update
'.' is not recognized as an internal or external command,
operable program or batch file.`

For this to work on windows, we need to change the postinstall command. I've edited to fix in the attached pull.

Hope this helps,
