### PR TITLE
Use keyless clone URL in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Getting started
 ---------------
 #### Installation
 ```
-git clone git@github.com:vmware/clarity-seed.git
+git clone https://github.com/vmware/clarity-seed.git
 cd clarity-seed
 
 # install the project's dependencies


### PR DESCRIPTION
The other URL requires local public key to be
added to your account. Switch to https to make
cloning keyless.