### PR TITLE
Use symlinked webdriver-manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "serve.prod": "gulp serve --prod",
     "build.dev": "gulp build",
     "build.prod": "gulp build --prod",
-    "postinstall": "node node_modules/protractor/bin/webdriver-manager update",
+    "postinstall": "webdriver-manager update",
     "test": "gulp test:unit",
     "test.e2e": "gulp test:e2e"
   }


### PR DESCRIPTION
npm scripts can find and run executables in ./node_modules/.bin
just by using their names. As these are links to actual bin files
in the respective packages, we can achieve the same result by
doing away with the path, which is also platform agnostic.

Signed-off-by: Nishant Shreshth <nishantshreshth@gmail.com>