### PR TITLE
Systemjs mapping configured for clarity-icons

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -40,6 +40,7 @@
         var packages = {
             'app': {main: 'index.js', defaultExtension: 'js'},
             'clarity-angular': {main: 'clarity-angular.umd.js', defaultExtension: 'js'},
+            'clarity-icons': {main: 'index.js', defaultExtension: 'js'},
             'rxjs': {main: 'Rx.js', defaultExtension: 'js'},
             '@angular/core': {main: 'bundles/core.umd.js', defaultExtension: 'js'},
             '@angular/compiler': {main: 'bundles/compiler.umd.js', defaultExtension: 'js'},
@@ -58,6 +59,7 @@
             <!-- @if NODE_ENV='dev' -->
             map: {
                 'clarity-angular': 'node_modules/clarity-angular',
+                'clarity-icons': 'node_modules/clarity-icons',
                 'rxjs': 'node_modules/rxjs',
                 '@angular/core': 'node_modules/@angular/core',
                 '@angular/common': 'node_modules/@angular/common',


### PR DESCRIPTION
This will be useful if users try to load clarity-icons in typescript files.

Signed-off-by: Shijir Tsogoo <stsogoo@vmware.com>