### PR TITLE
Fix AOT errors and use routerLinkActive for active class

### DIFF
--- a/src/app/about/about.component.ts
+++ b/src/app/about/about.component.ts
@@ -10,5 +10,6 @@ import { Component } from '@angular/core';
     templateUrl: './about.component.html'
 })
 export class AboutComponent {
+    open: Boolean = false;
 
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -17,11 +17,10 @@
   <nav class="sub-nav" [clr-nav-level]="1">
     <ul class="nav">
       <li class="nav-item">
-        <a class="nav-link" href="#" [routerLink]="['/home']"
-           [class.active]="router.url==='/home' || router.url==='/'">Home</a>
+        <a class="nav-link" href="#" [routerLink]="['/home']" routerLinkActive="active">Home</a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" href="#" [routerLink]="['/about']" [class.active]="router.url==='/about'">About</a>
+        <a class="nav-link" href="#" [routerLink]="['/about']" routerLinkActive="active">About</a>
       </li>
     </ul>
   </nav>


### PR DESCRIPTION
- use `routerLinkActive` instead of `[class.active]="router.url`in `app.component.html`
- fix for `Property 'open' does not exist on type 'AppComponent'` in AOT Build

Signed-off-by: Pratheek Hegde <ptk609@gmail.com>