### PR TITLE
Update the Clarity module import

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -20,7 +20,7 @@ import { AboutComponent } from "./about/about.component";
         BrowserModule,
         FormsModule,
         HttpModule,
-        ClarityModule.forRoot(),
+        ClarityModule,
         ROUTING
     ],
     providers: [],


### PR DESCRIPTION
We no longer need to call the `forRoot()` for the clarity module. 

Signed-off-by: Matt Hippely <mhippely@vmware.com>